### PR TITLE
fix: warning thrown migrating schema

### DIFF
--- a/projects/demo/src/assets/examples/ngx/buttons.json
+++ b/projects/demo/src/assets/examples/ngx/buttons.json
@@ -1,5 +1,6 @@
 {
     "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "items": {

--- a/projects/demo/src/assets/examples/ngx/containers.json
+++ b/projects/demo/src/assets/examples/ngx/containers.json
@@ -1,5 +1,6 @@
 {
     "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "items": {

--- a/projects/demo/src/assets/examples/ngx/hidden.json
+++ b/projects/demo/src/assets/examples/ngx/hidden.json
@@ -1,5 +1,6 @@
 {
     "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "apikey": {

--- a/projects/demo/src/assets/examples/ngx/simple-array.json
+++ b/projects/demo/src/assets/examples/ngx/simple-array.json
@@ -1,5 +1,6 @@
 {
     "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "items": {

--- a/projects/demo/src/assets/examples/ngx/templates.json
+++ b/projects/demo/src/assets/examples/ngx/templates.json
@@ -1,5 +1,6 @@
 {
     "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "items": {

--- a/projects/ngx-json-schema-form/src/lib/form/services/schema.service.ts
+++ b/projects/ngx-json-schema-form/src/lib/form/services/schema.service.ts
@@ -53,7 +53,7 @@ export class SchemaService implements SchemaAnalyzer {
     migrate(schema: JSONSchema4 | JSONSchema6 | JSONSchema7): JSONSchema7 {
         const migratedSchema = cloneDeep(schema);
         if (!migratedSchema.$schema || !migratedSchema.$schema.includes('draft-07')) {
-            if (!migratedSchema.$schema.includes('draft-06')) {
+            if (migratedSchema.$schema && migratedSchema.$schema.includes('draft-04')) {
                 migrate.draft6(migratedSchema);
             }
             // Per https://github.com/epoberezkin/json-schema-migrate/issues/1, draft 7 is

--- a/projects/ngx-json-schema-form/src/lib/form/services/schema.service.ts
+++ b/projects/ngx-json-schema-form/src/lib/form/services/schema.service.ts
@@ -52,8 +52,10 @@ export class SchemaService implements SchemaAnalyzer {
      */
     migrate(schema: JSONSchema4 | JSONSchema6 | JSONSchema7): JSONSchema7 {
         const migratedSchema = cloneDeep(schema);
-        if (!migratedSchema.$schema || (migratedSchema.$schema && !migratedSchema.$schema.includes('draft-07'))) {
-            migrate.draft6(migratedSchema);
+        if (!migratedSchema.$schema || !migratedSchema.$schema.includes('draft-07')) {
+            if (!migratedSchema.$schema.includes('draft-06')) {
+                migrate.draft6(migratedSchema);
+            }
             // Per https://github.com/epoberezkin/json-schema-migrate/issues/1, draft 7 is
             // fully backwards compatible with 6, so changing $schema should suffice?
             migratedSchema.$schema = 'http://json-schema.org/draft-07/schema#';


### PR DESCRIPTION
When migrating schemas, we don't want to migrate v6
as the library only handles 4 to 6 conversion

Closes #20